### PR TITLE
Upgrade dependency for gradle plugin for deployment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,13 @@ buildscript {
   }
   dependencies {
     classpath "de.seitenbau.ozghub.prozessdeployment:ozghub-prozessdeployment-gradle-plugin:2022-01-20-4"
-    classpath "de.seitenbau.serviceportal.prozesspipeline:prozess-pipeline-gradle-plugin:2021.12.14-0"
   }
 }
 
 plugins {
   id 'java'
   id 'groovy'
+  id "de.seitenbau.serviceportal.prozesspipeline" version "2022.09.01-0"
 }
 
 repositories {


### PR DESCRIPTION
While there were breaking changes to the API endpoint, no modifications (other than upgrading the plguin version) are necessary as the gradle plugin will use the new endpoint.