### PR TITLE
fix: remove trailing slash from url to prevent gradle task failure

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://sgwdev.behoerden-serviceportal.de/",
+  "url": "https://sgwdev.behoerden-serviceportal.de",
   "status": "EDIT"
 }


### PR DESCRIPTION
Including the trailing slash in the default url causes the gradle task `getActiveProcessEngines` to render an invalid url with double slashes, resulting in a failed call to the endpoint.

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':getActiveProcessEngines'.
> HTTP Response code 404 Not Found Meldung des Servers: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
  <html><head>
  <title>404 Not Found</title>
  </head><body>
  <h1>Not Found</h1>
  <p>The requested URL was not found on this server.</p>
  <p>Additionally, a 404 Not Found
  error was encountered while trying to use an ErrorDocument to handle the request.</p>
  </body></html>
   für URL https://sgwdev.behoerden-serviceportal.de//prozess/engine/aggregated
```

I believe the best solution would be to handle trailing slashes properly in the underlying implementation, but this change was so simple that it made sense to fix it immediately.