### PR TITLE
feat: fetch variable value from environment variable if possible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,13 +225,24 @@ def initJsonParameters()
   project.ext.set("jsonParameters", jsonParameters)
 }
 
-def getVariableValue(String name, defaultValue)
-{
-  def value = project.hasProperty(name)
-          ? project.property(name)
-          : project.jsonParameters[name] ?: defaultValue
+def getVariableValue(String name, defaultValue) {
+  def envValue = System.getenv("OZGH_${name.toUpperCase()}")
 
-  return value
+  if (envValue != null) {
+    return envValue
+  }
+
+  if (project.hasProperty(name)) {
+    return project.property(name)
+  }
+
+  def jsonValue = project.jsonParameters[name]
+
+  if (jsonValue != null) {
+    return jsonValue
+  }
+
+  return defaultValue
 }
 
 def getVariableValue(String name)

--- a/build.gradle
+++ b/build.gradle
@@ -226,20 +226,18 @@ def initJsonParameters()
 }
 
 def getVariableValue(String name, defaultValue) {
-  def envValue = System.getenv("OZGH_${name.toUpperCase()}")
-
-  if (envValue != null) {
-    return envValue
-  }
-
   if (project.hasProperty(name)) {
     return project.property(name)
   }
 
   def jsonValue = project.jsonParameters[name]
-
   if (jsonValue != null) {
     return jsonValue
+  }
+  
+  def envValue = System.getenv("OZGH_${name.toUpperCase()}")
+  if (envValue != null) {
+    return envValue
   }
 
   return defaultValue


### PR DESCRIPTION
### What’s Changed?

Previously, managing secrets required manually forwarding environment variables to Gradle tasks, which can be cumbersome — especially for frequent use. This pull request introduces **environment variable support** for gradle tasks, simplifying the integration of environment files and password managers. This change improves the developer experience by making secret management more seamless and less manual.

### Example

For example, if a team uses 1Password as their secret manager, developers can create an environment file referencing their secrets and easily use it in gadle commands.

#### Environment File
```bash
OZGH_URL=op://my-vault/my-secret/url
OZGH_USER=op://my-vault/my-secret/username
OZGH_PASSWORD=op://my-vault/my-secret/password
```

#### Command
```bash
op run --env-file="ozgh.env" -- ./gradlew listProcess
```

### Important Notes

- The user environment variable must now be named `OZGH_USER` instead of `OZGH_USERNAME`.